### PR TITLE
fix(script): change git format to fetch subject

### DIFF
--- a/git/commit-check.sh
+++ b/git/commit-check.sh
@@ -44,7 +44,7 @@ commit_message_check (){
       for i in `cat ./shafile.txt`;
       do 
       # gets the git commit message based on the sha
-      gitmessage=`git log --format=%B -n 1 "$i"`
+      gitmessage=`git log --format=%s -n 1 "$i"`
 
       # Checks gitmessage for string feat, fix, docs and breaking, if the messagecheck var is empty if fails
       messagecheck=$(echo $gitmessage | grep -w "feat\|fix\|docs\|breaking\|style\|refactor\|perf\|test\|chore")


### PR DESCRIPTION
while checking for commit message, only the subject of the message is required. The raw body can be ignored. This commit formats the `git log` to show only the subject.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>